### PR TITLE
[NTR-484] Add sending success upload email

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ Style/IfUnlessModifier:
 
 Metrics/LineLength:
   Max: 99
-  IgnoredPatterns: ['\A#']
+  IgnoredPatterns: ['(\A|\s)#']
 
 Metrics/BlockLength:
   ExcludedMethods: ['describe', 'context']

--- a/app/api_wrappers/base_api.rb
+++ b/app/api_wrappers/base_api.rb
@@ -51,6 +51,7 @@ class BaseApi
     def parse_body(body)
       JSON.parse(body.presence || '{}')
     rescue JSON::ParserError
+      Rails.logger.error "Error during parsing: #{body}"
       raise ApiException.new(500, 'Parse error', {})
     end
   end

--- a/app/controllers/upload_controller.rb
+++ b/app/controllers/upload_controller.rb
@@ -11,6 +11,8 @@ class UploadController < ApplicationController
     job_name = RegisterCheckerApi.register_job(file.original_filename, correlation_id)
     session[:job] = {
       name: job_name,
+      filename: file.original_filename,
+      submission_time: submission_time,
       correlation_id: correlation_id
     }
     redirect_to processing_upload_index_path
@@ -21,7 +23,6 @@ class UploadController < ApplicationController
     return if result == 'RUNNING'
 
     if result == 'SUCCESS'
-      session[:job] = nil
       redirect_to success_upload_index_path
     else
       redirect_to authenticated_root_path, alert: 'Uploaded file is not valid'
@@ -37,6 +38,27 @@ class UploadController < ApplicationController
 
   def data_rules
     # renders static page
+  end
+
+  ##
+  # Renders page after successful CSV file processing.
+  # Sends {SuccessEmail}[rdoc-ref:Ses::SendSuccessEmail] when visited first time after submission.
+  #
+  # ==== Path
+  #    GET /upload/success
+  #
+  # ==== Attributes
+  # * +job+ - hash in session
+  #   * +name+ - UUID, job name received from backend API
+  #   * +correlation_id+ - UUID, unique identifier used to communicate with backend API
+  #   * +filename+ - string, name of the submitted file
+  #   * +submission_time+ - string, time of the file submission in a proper format
+  #
+  def success
+    return unless session[:job]
+
+    Ses::SendSuccessEmail.call(user: current_user, job_data: job_data)
+    session[:job] = nil
   end
 
   private
@@ -68,5 +90,10 @@ class UploadController < ApplicationController
       Rails.logger.error 'Job identifier is missing'
       redirect_to root_path
     end
+  end
+
+  # returns current time in a proper format
+  def submission_time
+    Time.current.strftime(Rails.configuration.x.time_format)
   end
 end

--- a/app/mailers/upload_mailer.rb
+++ b/app/mailers/upload_mailer.rb
@@ -10,14 +10,20 @@ class UploadMailer < ApplicationMailer
   # ==== Attributes
   #
   # * +user+ - an instance of {User class}[rdoc-ref:User] with an email address set
+  # * +filename+ - string, name of the submitted file
+  # * +submission_time+ - string, time of the file submission in a proper format
   #
   # ==== Usage
   #
   #    user = User.new
   #    user.email = 'test@example.com'
-  #    UploadMailer.success_upload(user).deliver
+  #    filename = 'CAZ-2020-01-08-Leeds-1.csv'
+  #    time = Time.current.strftime(Rails.configuration.x.time_format)
+  #    UploadMailer.success_upload(user, filename, time).deliver
   #
-  def success_upload(user)
+  def success_upload(user, filename, submission_time)
+    @filename = filename
+    @submission_time = submission_time
     mail(to: user.email, subject: 'Upload successful')
   end
 end

--- a/app/services/ses/send_success_email.rb
+++ b/app/services/ses/send_success_email.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+##
+# Module used to send emails via AWS SES
+#
+module Ses
+  ##
+  # Sends an email to the user with successful CSV upload confirmation
+  #
+  # ==== Usage
+  #    user = User.new
+  #    user.email = 'test@example.com'
+  #    time = Time.current.strftime(Rails.configuration.x.time_format)
+  #    job_data = { filename: 'name.csv', submission_time: time }
+  #    SendSuccessEmail.call(user: user, job_data: job_data)
+  #
+  class SendSuccessEmail < BaseService
+
+    ##
+    # Initializer method for the class. Used by class level method {call}[rdoc-ref:BaseService::call]
+    #
+    # ==== Attributes
+    #
+    # * +user+ - an instance of {User class}[rdoc-ref:User] with an email address set
+    # * +job_data+ - hash with data about the upload job
+    #   * +filename+ - string, name of the submitted file
+    #   * +submission_time+ - string, time of the file submission as a string
+    def initialize(user:, job_data:)
+      @user = user
+      job_data = job_data.transform_keys(&:to_sym)
+      @filename = job_data[:filename]
+      @submission_time = job_data[:submission_time]
+    end
+
+    ##
+    # Executing method for the class. Used by class level method {call}[rdoc-ref:BaseService::call]
+    #
+    # Returns true if sending email was successful, false if not. Rescues all the errors.
+    #
+    def call
+      send_email
+      true
+    rescue StandardError => e
+      log_error(e)
+      false
+    end
+
+    private
+
+    # Calls the mailer class
+    def send_email
+      log_action("Sending :success_upload email to #{user.email}")
+      UploadMailer.success_upload(user, filename, submission_time).deliver
+      log_action('Email sent successfully')
+    end
+
+    # User instance
+    attr_reader :user
+    # Name of the submitted file
+    attr_reader :filename
+    # Time of the file submission
+    attr_reader :submission_time
+  end
+end

--- a/app/services/ses/send_success_email.rb
+++ b/app/services/ses/send_success_email.rb
@@ -15,7 +15,6 @@ module Ses
   #    SendSuccessEmail.call(user: user, job_data: job_data)
   #
   class SendSuccessEmail < BaseService
-
     ##
     # Initializer method for the class. Used by class level method {call}[rdoc-ref:BaseService::call]
     #
@@ -27,7 +26,6 @@ module Ses
     #   * +submission_time+ - string, time of the file submission as a string
     def initialize(user:, job_data:)
       @user = user
-      job_data = job_data.transform_keys(&:to_sym)
       @filename = job_data[:filename]
       @submission_time = job_data[:submission_time]
     end

--- a/app/views/upload_mailer/success_upload.html.haml
+++ b/app/views/upload_mailer/success_upload.html.haml
@@ -1,1 +1,8 @@
 %h3 Taxi and PHV centralised database has been successfully updated.
+
+%p
+  File named
+  = @filename
+  submitted on
+  = @submission_time
+  by you has been processed successfully.

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,9 @@ module CsvUploader
     feedback_url_default = 'https://www.surveymonkey.co.uk/r/2T8BX2D'
     config.x.feedback_url = (ENV['FEEDBACK_URL'].presence || feedback_url_default)
 
+    config.time_zone = 'London'
+    config.x.time_format = '%d %B %Y %H:%M:%S %Z'
+
     # https://mattbrictson.com/dynamic-rails-error-pages
     config.exceptions_app = routes
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,7 @@ module CsvUploader
 
     # https://github.com/aws/aws-sdk-rails
     config.action_mailer.delivery_method = :aws_sdk
+    # https://stackoverflow.com/questions/49086693/how-do-i-remove-mail-html-content-from-rails-logs
+    config.action_mailer.logger = nil
   end
 end

--- a/features/step_definitions/helper_steps.rb
+++ b/features/step_definitions/helper_steps.rb
@@ -83,3 +83,7 @@ end
 Then('I should not see {string} link') do |string|
   expect(page).not_to have_link(string)
 end
+
+When('I refresh the page') do
+  visit page.current_path
+end

--- a/features/step_definitions/upload_steps.rb
+++ b/features/step_definitions/upload_steps.rb
@@ -34,6 +34,10 @@ Then('I am redirected to the Success page') do
   expect(page).to have_current_path(success_upload_index_path)
 end
 
+Then('I receive a success upload email') do
+  expect(ActionMailer::Base.deliveries.size).to eq(1)
+end
+
 # Scenario: Upload a csv file and redirect to error page when api response not running or finished
 When('I press refresh page link when api response not running or finished') do
   allow(RegisterCheckerApi).to receive(:job_status)

--- a/features/step_definitions/upload_steps.rb
+++ b/features/step_definitions/upload_steps.rb
@@ -38,6 +38,10 @@ Then('I receive a success upload email') do
   expect(ActionMailer::Base.deliveries.size).to eq(1)
 end
 
+Then('I should not receive a success upload email again') do
+  expect(ActionMailer::Base.deliveries.size).to eq(1)
+end
+
 # Scenario: Upload a csv file and redirect to error page when api response not running or finished
 When('I press refresh page link when api response not running or finished') do
   allow(RegisterCheckerApi).to receive(:job_status)

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -17,6 +17,8 @@ Feature: Upload
     Then I am redirected to the Success page
       And I should see "Upload successful"
       And I receive a success upload email
+    When I refresh the page
+    Then I should not receive a success upload email again
 
   Scenario: Upload a csv file and redirect to error page when api response not running or finished
     Given I am on the Upload page

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -16,6 +16,7 @@ Feature: Upload
     When I press refresh page link
     Then I am redirected to the Success page
       And I should see "Upload successful"
+      And I receive a success upload email
 
   Scenario: Upload a csv file and redirect to error page when api response not running or finished
     Given I am on the Upload page

--- a/spec/mailers/previews/upload_mailer_preview.rb
+++ b/spec/mailers/previews/upload_mailer_preview.rb
@@ -7,6 +7,7 @@ class UploadMailerPreview < ActionMailer::Preview
   def success_upload
     user = User.new
     user.email = 'test@example.com'
-    UploadMailer.success_upload(user)
+    time = Time.current.strftime(Rails.configuration.x.time_format)
+    UploadMailer.success_upload(user, 'CAZ-2020-01-08-AuthorityID-1.csv', time)
   end
 end

--- a/spec/mailers/upload_mailer_spec.rb
+++ b/spec/mailers/upload_mailer_spec.rb
@@ -7,9 +7,19 @@ RSpec.describe UploadMailer, type: :mailer do
   let(:email) { 'test@example.com' }
 
   describe '.success_upload' do
-    subject(:mail) { described_class.success_upload(user) }
+    subject(:mail) { described_class.success_upload(user, filename, time) }
 
-    it { expect(mail.from).to include(ENV['SES_FROM_EMAIL']) }
+    let(:filename) { 'CAZ-2020-01-08-AuthorityID-1.csv' }
+    let(:time) { Time.current.strftime(Rails.configuration.x.time_format) }
+
     it { expect(mail.to).to include(email) }
+
+    it 'renders filename' do
+      expect(mail.body.encoded).to have_content(filename)
+    end
+
+    it 'renders submission time' do
+      expect(mail.body.encoded).to have_content(time)
+    end
   end
 end

--- a/spec/services/ses/send_success_email_spec.rb
+++ b/spec/services/ses/send_success_email_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Ses::SendSuccessEmail do
+  subject(:service_call) { described_class.call(user: user, job_data: job_data) }
+  let(:user) { new_user(email: email) }
+  let(:email) { 'user@example.com' }
+
+  let(:job_data) do
+    {
+      filename: filename,
+      submission_time: time
+    }
+  end
+  let(:filename) { 'CAZ-2020-01-08-AuthorityID-1.csv' }
+  let(:time) { Time.current.strftime(Rails.configuration.x.time_format) }
+
+  context 'with valid params' do
+    before do
+      mailer = OpenStruct.new(deliver: true)
+      allow(UploadMailer).to receive(:success_upload).and_return(mailer)
+    end
+
+    it 'returns true' do
+      expect(service_call).to be_truthy
+    end
+
+    it 'sends an email with proper params' do
+      expect(UploadMailer).to receive(:success_upload).with(user, filename, time)
+      service_call
+    end
+  end
+
+  context 'when sending emails fails' do
+    before do
+      allow(UploadMailer).to receive(:success_upload).and_raise(
+        Aws::SES::Errors::MessageRejected.new('', 'error')
+      )
+    end
+
+    it 'returns false' do
+      expect(service_call).to be_falsey
+    end
+  end
+end

--- a/spec/services/ses/send_success_email_spec.rb
+++ b/spec/services/ses/send_success_email_spec.rb
@@ -4,15 +4,10 @@ require 'rails_helper'
 
 RSpec.describe Ses::SendSuccessEmail do
   subject(:service_call) { described_class.call(user: user, job_data: job_data) }
+
   let(:user) { new_user(email: email) }
   let(:email) { 'user@example.com' }
-
-  let(:job_data) do
-    {
-      filename: filename,
-      submission_time: time
-    }
-  end
+  let(:job_data) { { filename: filename, submission_time: time } }
   let(:filename) { 'CAZ-2020-01-08-AuthorityID-1.csv' }
   let(:time) { Time.current.strftime(Rails.configuration.x.time_format) }
 


### PR DESCRIPTION
<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://eaflood.atlassian.net/browse/NTR-484

## Description
<!--- Describe your changes in detail -->
I added service for sending the success email with some controller changes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Submit a file, receive success from backend API, the email should be sent.
Remember about proper SES configuration.

## Screenshots (if appropriate):

![Screen Shot 2019-09-19 at 11 24 54](https://user-images.githubusercontent.com/16211686/65231691-36dcbf00-dad0-11e9-86b2-f19361de1b70.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] It contains only changes required by issue (does not contain other PR)
- [x] Includes a link to an issue (if apply)
- [x] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/... for new features cards (branched of master) --->
<!--- - hotfix/... for hotfixes (branched of master) --->
