### PR TITLE
Update heading layout on upload page

### DIFF
--- a/app/views/upload/index.html.haml
+++ b/app/views/upload/index.html.haml
@@ -5,12 +5,10 @@
         = render 'upload/job_errors'
       - elsif alert
         = render 'shared/errors'
-      %h1.govuk-heading-m
-        Welcome to the Taxi and PHV Data Portal
+      %h1.govuk-heading-m Welcome to the Taxi and PHV Data Portal
       %p
         You can use this service to upload and manage information about Taxis and PHVs in your licensing authority.
-      %h1.govuk-heading-m
-        Uploading your Taxi and PHV data
+      %h1.govuk-heading-m Uploading your Taxi and PHV data
       %p
         You’ll need to provide your data as a .CSV file and in a valid format.
         Otherwise your taxi and PHV data will not be uploaded into the service.


### PR DESCRIPTION
Update layout for headings for automated tests. The current layout causes elements to return with a white-space appended to the end.