### PR TITLE
Update yarn audit severity flag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -173,7 +173,7 @@ steps:
     pull: never
     commands:
        - bundle audit check --update
-       - yarn audit
+       - yarn audit --level moderate
        - brakeman
     volumes:
       - name: docker_sock
@@ -466,7 +466,7 @@ steps:
     pull: never
     commands:
        - bundle audit check --update
-       - yarn audit
+       - yarn audit --level moderate
        - brakeman
     volumes:
       - name: docker_sock


### PR DESCRIPTION
Update yarn audit severity flag in light of webpacker item. At present, no resolution is available from the maintainer (https://github.com/sass/node-sass/issues/2816), therefore, the resolution approach is to allow informational and lows to return a standard exit code (rather than non-zero).