### PR TITLE
CAZSM-9 filter out the vrn from all requests using the built in rails…

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,4 +3,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += %i[password confirmation_code]
+Rails.application.config.filter_parameters += %i[password confirmation_code vrn]


### PR DESCRIPTION
… configuration

<!--- When merging branch to dev please use the SQUASH AND MERGE --->

<!--- Before you open a PR: --->
<!--- !!! make a code review at least once a day (before standup?) !!! --->

## Motivation and Context
The VRN was being stored as incoming request parameters are logged by default by the 
Rails framework. This needed to be redacted from the log files for IG reasons.

## Description
Make a change to a default Rails initialisation parameter to include all parameters with the name
'vrn', so that these are no longer included in the logging output.

## How Has This Been Tested?
Tested locally that the VSN is no longer logged to stdout

## Screenshots (if appropriate):
![vrn_filtered](https://user-images.githubusercontent.com/48527330/80701436-4cd74700-8ad7-11ea-9d55-cc87c50e6be2.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] It contains only changes required by issue (does not contain other PR)
- [x ] Includes a link to an issue (if apply)
- [ ] I have added tests to cover my changes.

<!--- Branch naming conventions: --->
<!--- - feature/VCC-123/... for new features cards (branched of develop) --->
<!--- - bug/VCC-123/... for bugs (branched of develop) --->
