### PR TITLE
[NON-JIRA] Re-use docker image cache in dev publish to ECR step

### DIFF
--- a/.drone2.yml
+++ b/.drone2.yml
@@ -108,14 +108,6 @@ volumes:
     path: /var/run/docker.sock
 
 steps:
-  # Clean agent images and containers to prevent disk space overuse
-  - name: clean agent
-    image: docker:19.03.11-git
-    commands:
-    - docker system prune -f
-    volumes:
-      - name: docker_sock
-        path: /var/run/docker.sock
 
   # Build docker image
   - name: build
@@ -202,12 +194,16 @@ steps:
       registry: 311075478274.dkr.ecr.eu-west-2.amazonaws.com
       dockerfile: Dockerfile.build
       region: eu-west-2
+      use_cache: true
       tags:
         - latest
         - ${DRONE_BUILD_NUMBER}
       build_args:
         - secret_key_base=${DRONE_COMMIT}
         - AWS_REGION=eu-west-2
+    volumes:
+      - name: docker_sock
+        path: /var/run/docker.sock
     when:
       event:
         - push


### PR DESCRIPTION
Improves build speed and allows for docker image caching when pushing to ECR repository. This serves 2 benefits - one in that builds are 3 minutes faster to deploy; second - this reduces the number of pulls issued to Dockerhub (so reduces chance of hitting rate limits).