### PR TITLE
Bump mimemagic to 0.3.9

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -9,7 +9,7 @@ ARG secret_key_base
 ENV SECRET_KEY_BASE=$secret_key_base
 
 RUN apk add --no-cache --update build-base linux-headers tzdata nodejs \
-  openssh libxml2-dev libxslt-dev yarn curl-dev sqlite-dev \
+  openssh libxml2-dev libxslt-dev yarn curl-dev sqlite-dev shared-mime-info\
   && PACKAGES="ca-certificates procps curl pcre libstdc++ libexecinfo" \
   && BUILD_PACKAGES="pcre-dev libexecinfo-dev" \
   && apk add --update $PACKAGES $BUILD_PACKAGES \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -12,7 +12,7 @@ RUN apk add --no-cache --update build-base \
   sqlite-dev \
   git \
  && PACKAGES="ca-certificates procps curl pcre libstdc++ libexecinfo" \
- && BUILD_PACKAGES="pcre-dev libexecinfo-dev" \
+ && BUILD_PACKAGES="pcre-dev libexecinfo-dev shared-mime-info" \
  && apk add --update $PACKAGES $BUILD_PACKAGES \
  && rm -rf /var/cache/apk/*
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,7 +241,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
@@ -486,4 +486,4 @@ RUBY VERSION
    ruby 3.0.0p0
 
 BUNDLED WITH
-   2.2.3
+   2.2.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,7 +241,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
-    mimemagic (0.3.6)
+    mimemagic (0.3.9)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)


### PR DESCRIPTION
Recently there was a lot of drama around mimemagic gem - at first
mimemagic updated its licence to GPL2 to comply with its dependency
(freedesktop.org.xml) licence. In the process they yanked all
<0.3.6 licences and broke many builds (including ours) as 0.3.4
was direct dependency of Rails.

We have updated our Gemfile.lock to 0.3.6 to get our builds back
to green. This was yesterday. As of Today it looks like mimemagic
changed the owner. New owner extracted freedesktop.org.xml to be an outside
dependency, restored previous MIT licence, and again yanked all versions
<0.3.9 which again broke our build.

This commit bumps version to the closest available. We sincerely hope
we will not have to bump it again tomorrow.

If your build fails, please look at https://github.com/mimemagicrb/mimemagic#dependencies